### PR TITLE
Modify assembler to allow BBOS to build

### DIFF
--- a/DAsm.cpp
+++ b/DAsm.cpp
@@ -702,6 +702,9 @@ namespace DAsm{
         mChunks.emplace_back();
         mInstructions = &(mChunks.back().mInstructions);
         mCurChunk = &(mChunks.back());
+        
+        //RET isn't an opcode, but it means this.
+        AddMacro("RET=SET PC, POP");
     }
 
 

--- a/DAsm.cpp
+++ b/DAsm.cpp
@@ -796,8 +796,31 @@ namespace DAsm{
             }
             return result;
         }
-
-
+        
+        std::list<std::string> leftShiftParts;
+        splitString(expression,"<<",leftShiftParts,[](std::string str){return true;});
+        
+        if(leftShiftParts.size()>1){
+            result = Evaluate(leftShiftParts.front());
+            leftShiftParts.pop_front();
+            for(auto&& p: leftShiftParts){
+                result = result << Evaluate(p);
+            }
+            return result;
+        }
+        
+        std::list<std::string> rightShiftParts;
+        splitString(expression,">>",rightShiftParts,[](std::string str){return true;});
+        
+        if(rightShiftParts.size()>1){
+            result = Evaluate(rightShiftParts.front());
+            rightShiftParts.pop_front();
+            for(auto&& p: rightShiftParts){
+                result = result >> Evaluate(p);
+            }
+            return result;
+        }
+        
         std::list<std::string> multiplyParts;
         splitString(expression,"\\*",multiplyParts);
 

--- a/DAsm.cpp
+++ b/DAsm.cpp
@@ -508,7 +508,7 @@ namespace DAsm{
 
 
 
-            word value = mProgram->Evaluate(final_split_list.front());
+            int value = mProgram->Evaluate(final_split_list.front());
 
             mProgram->AddDefine(cur_str, value);
 
@@ -740,7 +740,7 @@ namespace DAsm{
     }
 
     //Define label value
-    void    Program::AddDefine(std::string nLabel,word nValue){
+    void    Program::AddDefine(std::string nLabel,int nValue){
         if(mIgnoreLabelCase)
             transform(nLabel.begin(), nLabel.end(), nLabel.begin(), ::toupper);
         mDefineValues.push_back(label_value(nLabel, nValue));
@@ -1009,17 +1009,27 @@ namespace DAsm{
                     }
                 }
             }
-
-            //Update label positions from relative to absolute
-            for(auto&& o : mOrdered){
-
-                for(auto && l : o->mLabelValues){
-                    l.value += o->mTargetPos;
-                }
-            }
         }else{
+            //Chunks with target positions get assembled as if they are there.
+            //Chunks with no target positions get assigned their actual positions.
+            //This is useful if your code moves itself around.
+            int start = 0;
             for(auto&& c : mChunks){
+                if(!c.mHasTargetPos){
+                    //Tell it it is where it actually is.
+                    c.mTargetPos = start;
+                    c.mHasTargetPos = true;
+                }
                 mOrdered.push_back(&c);
+                start += c.GetLength();
+            }
+        }
+        
+        //Update label positions from relative to absolute
+        //This needs to happen whether chunks are arranged or not.
+        for(auto&& o : mOrdered){
+            for(auto && l : o->mLabelValues){
+                l.value += o->mTargetPos;
             }
         }
 

--- a/DAsm.cpp
+++ b/DAsm.cpp
@@ -416,7 +416,48 @@ namespace DAsm{
             }
             return;
         }
-
+        
+        //null-terminated strings, one character per word
+        if(first_str=="ASCIIZ"||first_str==".ASCIIZ"){
+            while(final_split_list.size()){
+                std::string cur_str = *final_split_list.begin();
+                bool is_quote = *is_quote_list.begin();
+                
+                final_split_list.pop_front();
+                is_quote_list.pop_front();
+                
+                if(is_quote){//Quotes get turned into character values
+                    for(auto c = cur_str.begin(); c!= cur_str.end(); ++c){
+                        if(*c == '\\'){
+                            if(next(c) != cur_str.end()){
+                                if(*next(c) == '\\'){
+                                    mWords.push_back(word('\\'));
+                                    ++c;
+                                    continue;
+                                }
+                            }
+                        }else{
+                            mWords.push_back(word(*c));
+                        }
+                    }
+                }else{//Otherwise interpret as values/labels
+                    bool number;
+                    int value = getNumber(cur_str,number);
+                    if(number){
+                        mWords.push_back(word(value));
+                        continue;
+                    }else{
+                        mWords.push_back(word(0x1234));
+                        mProgram->AddExpressionTarget(cur_str, &(mWords.back()));
+                    }
+                }
+                
+                // Add the null terminator
+                mWords.push_back(word(0));
+            }
+            return;
+        }
+        
         //Handles the org stuff, splitting code into chunks
         if(first_str=="ORG"||first_str==".ORG"){
             if(final_split_list.size()==0){

--- a/DAsm.cpp
+++ b/DAsm.cpp
@@ -140,6 +140,20 @@ namespace DAsm{
         return 0xFF;
     }
 
+    // Returns true of an opcode needs arguments, false otherwise
+    bool    Instruction::GetArgumentFlag(std::string str){
+        for(auto&& i : mOpcodes){
+            if(i.str == str)
+                return i.arguments;
+        }
+        for(auto&& i : mSpecialOpcodes){
+            if(i.str == str)
+                return i.arguments;
+        }
+        Error(std::string("Opcode not found: ").append(str));
+        return true;
+    }
+
     //Returns length of instruction in words
     unsigned int    Instruction::GetLength(){
         return mWords.size();
@@ -587,11 +601,13 @@ namespace DAsm{
         if(lOp==0x00){
             lOp = GetSpecialOpcode(first_str);
             lWord |= lOp << 5;
-            if(final_split_list.size()<1){
-                Error(first_str.append(std::string(" opcode requires an operand")));
-                return;
+            if(GetArgumentFlag(first_str)) {
+                if(final_split_list.size()<1){
+                    Error(first_str.append(std::string(" opcode requires an operand")));
+                    return;
+                }
+                lWord |= ParseArg(*final_split_list.begin(), true) << 10;
             }
-            lWord |= ParseArg(*final_split_list.begin(), true) << 10;
         }else{
             if(final_split_list.size()<2){
                 Error(first_str.append(std::string(" requires two operands")));
@@ -663,7 +679,7 @@ namespace DAsm{
         Instruction::mSpecialOpcodes.push_back(str_opcode("INT", 0x08));
         Instruction::mSpecialOpcodes.push_back(str_opcode("IAG", 0x09));
         Instruction::mSpecialOpcodes.push_back(str_opcode("IAS", 0x0A));
-        Instruction::mSpecialOpcodes.push_back(str_opcode("RFI", 0x0B));
+        Instruction::mSpecialOpcodes.push_back(str_opcode("RFI", 0x0B, false));
         Instruction::mSpecialOpcodes.push_back(str_opcode("IAQ", 0x0C));
         Instruction::mSpecialOpcodes.push_back(str_opcode("HWN", 0x10));
         Instruction::mSpecialOpcodes.push_back(str_opcode("HWQ", 0x11));

--- a/DAsm.cpp
+++ b/DAsm.cpp
@@ -332,41 +332,19 @@ namespace DAsm{
             std::regex split_semicolon(";");
             std::sregex_token_iterator remove_comment(part->begin(), part->end(), split_semicolon, -1);
             *part = remove_comment->str();//Grab only the first bit (others will be comment)
+            
+            std::list<std::string> token_list;
+            splitString(*part, "(\\s|\\t|,)", token_list);//Split around commas and space
 
-            std::list<std::string> comma_split_list;
-            splitString(*part, ",", comma_split_list);//Split around commas
-
-            if(comma_split_list.size() == 0){//Line is only comment
+            if(token_list.size() == 0){//Line is only comment
                 return;
             }
-
-            std::string first_str = *(comma_split_list.begin());
-
-            std::list<std::string> split_first;
-            splitString(first_str, "(\\s|\\t)+", split_first);//Split first string around spaces
-
-
-            if(split_first.size()){
-
-                final_split_list.push_back(split_first.front());
-                is_quote_list.push_back(false);
-
-                if(split_first.size()>1){//Join the rest, since only the first bit needs to be on its own
-                    std::string second =first_str.substr(first_str.find(split_first.front())+split_first.front().size());
-                    second.erase(remove_if(second.begin(), second.end(),
-                                           [](char x){return std::isspace(x,std::locale());}), second.end());
-
-                    final_split_list.push_back(second);
-                    is_quote_list.push_back(false);
-                }
-            }
-            comma_split_list.pop_front();
-
-            for(auto&& i : comma_split_list)//Cleanup any stray spaces
+            
+            for(auto&& i : token_list)//Cleanup any stray spaces
                 i.erase(remove_if(i.begin(), i.end(),
                                   [](char x){return std::isspace(x,std::locale());}), i.end());
-
-            copy_if(comma_split_list.begin(), comma_split_list.end(),
+            
+            copy_if(token_list.begin(), token_list.end(),
                     back_inserter(final_split_list),
                     [&](std::string str){
                         if(str.size()){
@@ -796,7 +774,7 @@ namespace DAsm{
             }
             return result;
         }
-        
+
         std::list<std::string> leftShiftParts;
         splitString(expression,"<<",leftShiftParts,[](std::string str){return true;});
         
@@ -808,7 +786,7 @@ namespace DAsm{
             }
             return result;
         }
-        
+
         std::list<std::string> rightShiftParts;
         splitString(expression,">>",rightShiftParts,[](std::string str){return true;});
         

--- a/DAsm.cpp
+++ b/DAsm.cpp
@@ -702,6 +702,9 @@ namespace DAsm{
         mChunks.emplace_back();
         mInstructions = &(mChunks.back().mInstructions);
         mCurChunk = &(mChunks.back());
+        //Always start assembling at 0 unless otherwise specified.
+        mCurChunk->mHasTargetPos = true;
+        mCurChunk->mTargetPos = 0;
         
         //RET isn't an opcode, but it means this.
         AddMacro("RET=SET PC, POP");

--- a/DAsm.cpp
+++ b/DAsm.cpp
@@ -479,6 +479,15 @@ namespace DAsm{
             Fill(value, amount);
             return;
         }
+        
+        if(first_str=="RESERVE"||first_str==".RESERVE"){
+            if(final_split_list.size()==0)
+                return;
+            
+            unsigned int amount = mProgram->Evaluate(final_split_list.front());
+            Fill(0, amount);
+            return;
+        }
         //Passes to macro system
         if(first_str=="FLAG"||first_str==".FLAG"){
             std::string flag_str = final_split_list.front();

--- a/DAsm.h
+++ b/DAsm.h
@@ -119,6 +119,7 @@ class   Program{
 
         void                                AddLabelValue(std::string nLabel, word nValue);
         void                                AddDefine(std::string nLabel, int nValue);
+        std::string                         GlobalizeLabels(std::string nExpression);
 
         unsigned int                        GetLength();
         unsigned int                        mLength;
@@ -141,6 +142,8 @@ class   Program{
 
         std::list<ProgramChunk>             mChunks;
         std::list<ProgramChunk*>            mOrdered;
+        
+        std::string                         mGlobalLabel;
 
         std::list<label_value>              mDefineValues;
 

--- a/DAsm.h
+++ b/DAsm.h
@@ -39,10 +39,11 @@ struct  expression_target{
 };
 
 //Store values of labels
+//Stores int-width values for extra-long defines
 struct label_value{
     std::string label;
-    word    value;
-    label_value(std::string nLabel, word nValue){label=nLabel; value=nValue;}
+    int    value;
+    label_value(std::string nLabel, int nValue){label=nLabel; value=nValue;}
 };
 
 struct macro{
@@ -117,7 +118,7 @@ class   Program{
         void                                AddIncrementTarget(std::string nExpression,word* nTarget);
 
         void                                AddLabelValue(std::string nLabel, word nValue);
-        void                                AddDefine(std::string nLabel, word nValue);
+        void                                AddDefine(std::string nLabel, int nValue);
 
         unsigned int                        GetLength();
         unsigned int                        mLength;

--- a/DAsm.h
+++ b/DAsm.h
@@ -28,7 +28,8 @@ const unsigned int MAX_RECURSION = 20;
 struct  str_opcode{
     std::string  str;
     opcode  value;
-    str_opcode(std::string nStr, opcode nValue){str=nStr; value=nValue;}
+    bool arguments;
+    str_opcode(std::string nStr, opcode nValue, bool nArguments = true){str=nStr; value=nValue; arguments=nArguments;}
 };
 //Store words to be replaced with expression values
 struct  expression_target{
@@ -69,6 +70,7 @@ class   Instruction{
 
         opcode                              GetOpcode(std::string str);
         opcode                              GetSpecialOpcode(std::string str);
+        bool                                GetArgumentFlag(std::string str);
 
         void                                Error(std::string nError);
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+# Default settings
+CPPFLAGS += -g -std=c++11
+LDFLAGS += 
+# Note that you need a compiler actually implementing std::regex (not gcc 4.8)
+
+all: demo dasm
+
+demo: main.o DAsm.o
+	$(CXX) $^ -o $@ $(LDFLAGS)
+	
+dasm: driver.o DAsm.o
+	$(CXX) $^ -o $@ $(LDFLAGS)
+	
+clean:
+	rm -f *.o demo dasm
+	

--- a/driver.cpp
+++ b/driver.cpp
@@ -1,0 +1,137 @@
+// Driver program to assemble code
+
+#include <iostream>
+#include <string>
+#include <fstream>
+#include <sstream>
+#include <algorithm>
+
+
+#include "DAsm.h"
+
+/**
+ * Load a file, processing any .include or #include directives.
+ */
+std::string getFile(std::string filename) {
+    // We'll just cat everything into this stream.
+    std::stringstream result;
+    
+    std::cerr << "Loading " << filename << std::endl;
+    
+    // Open the file
+    std::ifstream file(filename);
+    
+    // TODO: warn about missing files
+    
+    size_t line_number = 0;
+    
+    std::string line;
+    while(std::getline(file, line)){
+        
+        line_number++;
+        
+        size_t offset = 0;
+        while(offset < line.size() && ::isspace(line[offset])) {
+            // Skip any leading spaces
+            offset++;
+        }
+        // This is the start of the first word.
+        size_t word_start = offset;
+        
+        while(offset < line.size() && !::isspace(line[offset])) {
+            // Skip anything that isn't a space
+            offset++;
+        }
+        // This is the end of the first word.
+        size_t word_end = offset;
+        
+        if(word_start < line.size() && word_end < line.size()) {
+        
+            // We found a first word. Clip it out.
+            std::string first_str = line.substr(word_start, word_end - word_start);
+            std::string rest_str = line.substr(word_end);
+            
+            // Capitalize the first part
+            std::transform(first_str.begin(), first_str.end(), first_str.begin(), ::toupper);
+            
+            if(first_str == "INCLUDE" || first_str == ".INCLUDE" || first_str == "#INCLUDE"){
+                // Handle an include
+                
+                // Trim whitespace, quotes, and brackets from the filename
+                std::string included_filename = rest_str;
+                
+                // Match file, "file", and <file>
+                size_t start = included_filename.find_first_not_of(" \t'\"<");
+                size_t end = included_filename.find_last_not_of(" \t'\">") + 1;
+                
+                if(start < included_filename.size() && end <= included_filename.size() && start <= end) {
+                
+                    // Trim out just the filename
+                    included_filename = included_filename.substr(start, end - start);
+                    
+                    // TODO: catch include loops
+                    
+                    // Recurse
+                    result << getFile(included_filename);
+                
+                    // Don't take this line
+                    continue;
+                    
+                } else {
+                    std::cerr << "Preprocessor error: " << filename << ": " << line_number << ": Incorrect include syntax" << std::endl;
+                    std::cerr << line << std::endl;
+                    exit(1);
+                }
+                
+            }
+        }
+        
+        // If we get here it wasn't an include. Use the line.
+        result << line << std::endl;
+    }
+    
+    // Get the string and return it
+    return result.str();
+}
+
+int main(int argc, char** argv) {
+
+    if(argc < 3) {
+        std::cerr << "Usage: " << argv[0] << " input.asm output.bin" << std::endl;
+        return 1;
+    }
+
+    // Load up the source code.
+    std::string source = getFile(argv[1]);
+
+    DAsm::Program lProgram;
+
+    if(lProgram.LoadSource(source)){
+        // It compiled.
+        unsigned long pSize;
+        //The parameters in this call are optional
+        DAsm::word* lMemory = lProgram.ToBlock(DAsm::DCPU_RAM_SIZE, pSize);
+        
+        // Open the output file
+        std::ofstream out(argv[2]);
+        
+        // Dump the program to disk in big endian byte order
+        for(int i = 0; i < pSize; i++){
+            // Break into bytes
+            unsigned char bytes[2];
+            bytes[0] = lMemory[i] >> 8;
+            bytes[1] = lMemory[i] & 0xFF;
+            
+            // Write the bytes
+            out.write((char*) bytes, 2);
+        }
+        std::cout << "Wrote "<< pSize << " words to " << argv[2] << std::endl;
+        delete lMemory;
+    }else{
+        for(auto&& error : lProgram.mErrors){
+            std::cerr << "Error: " << error << std::endl;
+        }
+        return 1;
+    }
+    return 0;    
+}


### PR DESCRIPTION
This version allows @MadMockers 's BBOS to build. Specifically, the full version, [bbos.asm](https://github.com/MadMockers/BareBonesOS/blob/master/src/bbos.asm). Since that's supposed to be used in the game, I figured it would be good if the game's assembler could build it. I also want to use BBOS in *my* game (which may or may not ever see the light of day), and I needed an assembler that can build it.

This closes #5, as that commit, rebased on the current master, is in here.

Notable changes:

* Added a command-line driver with include support (which BBOS needs).
* Made re-arranging `ORG` sections be off by default, as BBOS has `ORG` directives for high memory, but then expects to be able to copy itself from low memory to high memory.
* Add support for left and right shift expressions `<<` and `>>`, which BBOS uses.
* Tokenize on spaces and commas , to allow BBOS-style `.define thing value` syntax.
* Add a `RESERVE` assembler directive, which produces a specified number of zero-words, as used in BBOS.
* Fix `RFI` wanting an operand. Closes #2.
* Add a default macro implementing `RET`, which BBOS uses.
* Tell the first chunk to start at 0 when it is created. When chunk arranging was on, it was getting arranged to arbitrary places, since it ostensibly didn't care. It might make sense to start with an `ORG 0`, but BBOS doesn't. Since chunk arranging is off by default, this may not be necessary any more.
* Fix up complex argument parsing. When `[]` were used, and when multiple additions and subtractions were used, the index into the original string was getting out of sync with the consumed tokens. I threw out the index idea and just do case conversion on the tokens.
* Allow `DEFINE` values to be int width (32 bits on most platforms). BBOS uses 32-bit `DEFINE`s for hardware IDs, and shifts and ANDs them out into pairs of literal words.
* Global and local labels. BBOS has multiple instances of labels that start with `.`. They're supposed to be local to a global label: the most recent label not starting with `.`. I made local labels have the appropriate global label name be prepended to them depending on where they occur. To make this work in expressions, I had to prohibit labels from having internal `.`s. You're supposed to be able to reference local labels with fully-qualified `global.local` names, but BBOS doesn't use that and implementing it would require properly parsing expressions when adding context to the labels they contain.

I've successfully gotten BBOS to compile without errors, and display the "No bootable media found" message in [dtemu](https://github.com/DCPUTeam/DCPUToolchain/tree/master/dtemu). I haven't actually bootloaded anything with it, so there may still be bugs.

