### PR TITLE
Fix commas after quoted strings

### DIFF
--- a/DAsm.cpp
+++ b/DAsm.cpp
@@ -391,9 +391,9 @@ namespace DAsm{
                 splitString(*part, ",", token_list);//Split what wasn't used already around commas to get the other arguments
             }
             
-            for(auto&& i : token_list)//Cleanup any stray spaces
+            for(auto&& i : token_list)//Cleanup any stray spaces or commas
                 i.erase(remove_if(i.begin(), i.end(),
-                                  [](char x){return std::isspace(x,std::locale());}), i.end());
+                                  [](char x){return std::isspace(x,std::locale()) || x == ',';}), i.end());
 
             copy_if(token_list.begin(), token_list.end(),
                     back_inserter(final_split_list),
@@ -896,7 +896,6 @@ namespace DAsm{
 
     //Evaluates an expression
     int    Program::Evaluate(std::string expression){
-    
         if(expression.size()==0)
             return 0;
         //Basically we just go through each operator in order


### PR DESCRIPTION
Since parsing basically starts over after a quoted string, a quoted
string followed by a comma was producing a comma as a parsed
token.

It still can't remember if comma-separated parsing was in use
before the quoted string, and will handle space-separated values
after a quoted string strangely, but `DAT "some text", 0` should
work again.